### PR TITLE
Removed Pointer Reference

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -372,7 +372,7 @@ users:
 `, containerUsername, containerPassword)
 	}
 
-	var rop *lxd.RemoteOperation
+	var rop lxd.RemoteOperation
 	if config.Container != "" {
 		args := lxd.ContainerCopyArgs{
 			Name:          containerName,


### PR DESCRIPTION
I wasn't able to run go build with rest.go line 375 using a pointer to the interface. Removing the pointer reference and passing the interface itself built and runs for me.