### PR TITLE
Match the protocol when making http requests

### DIFF
--- a/static/js/tryit.js
+++ b/static/js/tryit.js
@@ -2,6 +2,8 @@ $(document).ready(function() {
     var tryit_terms_hash = "";
     var tryit_console = "";
     var tryit_server = location.host;
+    var tryit_server_protocol = location.protocol;
+    var tryit_server_ws_protocol = (tryit_server_protocol === "http:") ? "ws:" : "wss:";
     var original_url = window.location.href.split("?")[0];
     var term = null
     var sock = null
@@ -74,7 +76,7 @@ $(document).ready(function() {
         var height = Math.max(Math.round(window.innerHeight / 25), 15);
         var width = size.cols - 1;
 
-        sock = new WebSocket("ws://"+tryit_server+"/1.0/console?id="+id+"&width="+width+"&height="+height);
+        sock = new WebSocket(tryit_server_ws_protocol+"//"+tryit_server+"/1.0/console?id="+id+"&width="+width+"&height="+height);
         sock.onopen = function (e) {
             term = new Terminal({
                 cols: width,
@@ -166,7 +168,7 @@ $(document).ready(function() {
 
     if (tryit_console == "") {
         $.ajax({
-            url: "http://"+tryit_server+"/1.0",
+            url: tryit_server_protocol+"//"+tryit_server+"/1.0",
             success: function(data) {
                 if (data.server_console_only == true) {
                     $('#tryit_ssh_row').css("display", "none");
@@ -189,7 +191,7 @@ $(document).ready(function() {
                 $('#tryit_status_panel').css("display", "inherit");
 
                 $.ajax({
-                    url: "http://"+tryit_server+"/1.0/terms"
+                    url: tryit_server_protocol+"//"+tryit_server+"/1.0/terms"
                 }).then(function(data) {
                     tryit = data;
                     $('#tryit_terms').html(data.terms);
@@ -209,7 +211,7 @@ $(document).ready(function() {
         });
     } else {
         $.ajax({
-            url: "http://"+tryit_server+"/1.0/info?id="+tryit_console,
+            url: tryit_server_protocol+"//"+tryit_server+"/1.0/info?id="+tryit_console,
             success: function(data) {
                 if (data.status && data.status != 0) {
                     $('#tryit_start_panel').css("display", "none");
@@ -253,7 +255,7 @@ $(document).ready(function() {
         $('#tryit_progress').css("display", "inherit");
 
         $.ajax({
-            url: "http://"+tryit_server+"/1.0/start?terms="+tryit_terms_hash
+            url: tryit_server_protocol+"//"+tryit_server+"/1.0/start?terms="+tryit_terms_hash
         }).then(function(data) {
             if (data.status && data.status != 0) {
                 if (data.status == 1) {


### PR DESCRIPTION
This PR will attempt to match the protocol being used to serve the application. It removes hard coding of the `http:` protocol and selects the protocol based on the value of `location.protocol`. This is handy if you're running the server behind a reverse proxy that is handling TLS termination.

My current use case is runnign the demo server behind a tailscale funnel to test with some colleagues.